### PR TITLE
Make use of the scale of the display to generate the correct dimensions for the blurred image.

### DIFF
--- a/Classes/UIImage+StackBlur.m
+++ b/Classes/UIImage+StackBlur.m
@@ -127,7 +127,7 @@ inline static void zeroClearInt(int* p, size_t count) { memset(p, 0, sizeof(int)
 
     const size_t dvcount = 256 * divsum;
     int *dv = malloc(sizeof(int) * dvcount);
-	for (int i = 0;i < dvcount;i++) {
+	for (size_t i = 0;i < dvcount;i++) {
 		dv[i] = (i / divsum);
 	}
     


### PR DESCRIPTION
Hi @tomsoft1,

just discovered that the code you are providing for blurring an image is not using the scale of the display when creating a new blurred image. I fixed also a type warning.  Would be nice if you can merge the snippet :)

Cheers from Berlin
