### PR TITLE
Fixed compiler warning

### DIFF
--- a/Classes/UIImage+StackBlur.m
+++ b/Classes/UIImage+StackBlur.m
@@ -127,7 +127,7 @@ inline static void zeroClearInt(int* p, size_t count) { memset(p, 0, sizeof(int)
 
     const size_t dvcount = 256 * divsum;
     int *dv = malloc(sizeof(int) * dvcount);
-	for (int i = 0;i < dvcount;i++) {
+	for (int i = 0;(size_t)i < dvcount;i++) {
 		dv[i] = (i / divsum);
 	}
     


### PR DESCRIPTION
This Pull Request fix a compiler warning when directive -Wall is enabled.

The warning was about the comparison between an int and a size_t (unsigned) type. While the int is positive there is no problem, but to avoid the warning I added a cast (size_t) to the integer.
