### PR TITLE
Project settings updated with Xcode 7, compile warnings fixed

### DIFF
--- a/Classes/UIImage+StackBlur.m
+++ b/Classes/UIImage+StackBlur.m
@@ -60,7 +60,7 @@ inline static void zeroClearInt(int* p, size_t count) { memset(p, 0, sizeof(int)
     //	return [other applyBlendFilter:filterOverlay  other:self context:nil];
 	// First get the image into your data buffer
     CGImageRef inImage = self.CGImage;
-    int nbPerCompt = CGImageGetBitsPerPixel(inImage);
+    int nbPerCompt = (int)CGImageGetBitsPerPixel(inImage);
     if(nbPerCompt != 32){
         UIImage *tmpImage = [self normalize];
         inImage = tmpImage.CGImage;
@@ -83,8 +83,8 @@ inline static void zeroClearInt(int* p, size_t count) { memset(p, 0, sizeof(int)
 											 );
 	
     // Apply stack blur
-    const int imageWidth  = CGImageGetWidth(inImage);
-	const int imageHeight = CGImageGetHeight(inImage);
+    const int imageWidth  = (int)CGImageGetWidth(inImage);
+	const int imageHeight = (int)CGImageGetHeight(inImage);
     [self.class applyStackBlurToBuffer:m_PixelBuf
                                  width:imageWidth
                                 height:imageHeight
@@ -104,7 +104,7 @@ inline static void zeroClearInt(int* p, size_t count) { memset(p, 0, sizeof(int)
 
 + (void) applyStackBlurToBuffer:(UInt8*)targetBuffer width:(const int)w height:(const int)h withRadius:(NSUInteger)inradius {
     // Constants
-	const int radius = inradius; // Transform unsigned into signed for further operations
+	const int radius = (int)inradius; // Transform unsigned into signed for further operations
 	const int wm = w - 1;
 	const int hm = h - 1;
 	const int wh = w*h;

--- a/stackBlur-Info.plist
+++ b/stackBlur-Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.yourcompany.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/stackBlur.xcodeproj/project.pbxproj
+++ b/stackBlur.xcodeproj/project.pbxproj
@@ -140,6 +140,9 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0720;
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "stackBlur" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -197,6 +200,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = stackBlur_Prefix.pch;
 				INFOPLIST_FILE = "stackBlur-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.yourcompany.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = stackBlur;
 			};
 			name = Debug;
@@ -209,6 +213,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = stackBlur_Prefix.pch;
 				INFOPLIST_FILE = "stackBlur-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.yourcompany.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = stackBlur;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -217,11 +222,12 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
 				SDKROOT = iphoneos;
 			};
@@ -230,7 +236,6 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;


### PR DESCRIPTION
Project was opened with Xcode 7 and updated to suggested settings.
"Implicit conversion loses integer precision" warnings were fixed by a cast to int.